### PR TITLE
Update README: The latest Python is 3.10.8 now

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Note: Do NOT edit directly, this file was generated using https://github.com/cha
 
 [![CI status](https://github.com/chainguard-images/python/actions/workflows/release.yaml/badge.svg)](https://github.com/chainguard-images/python/actions/workflows/release.yaml)
 
-This is a minimal Python image based on Alpine, using Python apks available on the Alpine Community repositories (not built from source as of now).<br/><br/>While this image is being developed, we will stick to the latest stable Python version which at this moment is `3.10.7`. Supported versions in the long term are TBD.
+This is a minimal Python image based on Alpine, using Python apks available on the Alpine Community repositories (not built from source as of now).<br/><br/>While this image is being developed, we will stick to the latest stable Python version which at this moment is `3.10.8`. Supported versions in the long term are TBD.
 
 ## Get It!
 


### PR DESCRIPTION
The image already has 3.10.8. It just needs to say so in the README.

Signed-off-by: Michael A. Smith <michael@smith-li.com>